### PR TITLE
[Release] Update install script to beta 11

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 
 REPO="attestation-service-cli"
 APP="bky-as"
-VERSION="v0.1.0-beta.10"
+VERSION="v0.1.0-beta.11"
 
 # let the user know a step was successful
 function passCheck() {


### PR DESCRIPTION
Following the release [checklist](https://blocky.atlassian.net/wiki/spaces/BLOC/pages/2339340289/Delphi+Release+v0.1.0-beta.11) for beta 11, this PR updates the install script to install beta 11
